### PR TITLE
feat: add dark/light theme toggle (closes #3)

### DIFF
--- a/src/app/accounts/account-list/account-list.component.scss
+++ b/src/app/accounts/account-list/account-list.component.scss
@@ -1,12 +1,12 @@
-.page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; h1 { font-size: 28px; color: #1a237e; margin: 0; } .subtitle { color: #666; font-size: 14px; margin-top: 4px; } }
-.btn { padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; &.primary { background: #1976d2; color: #fff; } }
+.page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; h1 { font-size: 28px; color: var(--text-heading); margin: 0; } .subtitle { color: var(--text-secondary); font-size: 14px; margin-top: 4px; } }
+.btn { padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; &.primary { background: var(--accent-color); color: #fff; } }
 .accounts-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px; }
-.account-card { background: #fff; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); overflow: hidden; }
-.account-header { display: flex; align-items: center; gap: 14px; padding: 20px 24px; border-bottom: 1px solid #f0f0f0; h4 { margin: 0; color: #1a237e; } }
+.account-card { background: var(--bg-card); border-radius: 12px; box-shadow: 0 2px 8px var(--shadow-color); overflow: hidden; transition: background-color 0.3s ease; }
+.account-header { display: flex; align-items: center; gap: 14px; padding: 20px 24px; border-bottom: 1px solid var(--border-light); h4 { margin: 0; color: var(--text-heading); } }
 .account-icon { width: 48px; height: 48px; border-radius: 12px; display: flex; align-items: center; justify-content: center; font-weight: 700; color: #fff; font-size: 16px; &.blue { background: #1976d2; } &.green { background: #43a047; } &.purple { background: #7b1fa2; } &.orange { background: #ef6c00; } }
-.plan { display: inline-block; margin-top: 4px; padding: 2px 10px; border-radius: 10px; font-size: 11px; font-weight: 600; &.enterprise { background: #fce4ec; color: #c62828; } &.pro { background: #e3f2fd; color: #1565c0; } &.starter { background: #fff3e0; color: #e65100; } }
+.plan { display: inline-block; margin-top: 4px; padding: 2px 10px; border-radius: 10px; font-size: 11px; font-weight: 600; &.enterprise { background: var(--negative-bg); color: var(--negative-text); } &.pro { background: rgba(25, 118, 210, 0.15); color: var(--accent-color); } &.starter { background: rgba(230, 81, 0, 0.15); color: #ef6c00; } }
 .account-body { padding: 16px 24px; display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
-.metric { text-align: center; span { display: block; font-size: 12px; color: #888; } strong { font-size: 16px; color: #1a237e; } }
-.account-footer { display: flex; justify-content: space-between; align-items: center; padding: 14px 24px; background: #fafafa; }
-.status { padding: 3px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; &.active { background: #e8f5e9; color: #2e7d32; } &.trial { background: #fff3e0; color: #e65100; } }
-.link { color: #1976d2; font-size: 13px; cursor: pointer; font-weight: 500; &:hover { text-decoration: underline; } }
+.metric { text-align: center; span { display: block; font-size: 12px; color: var(--text-muted); } strong { font-size: 16px; color: var(--text-heading); } }
+.account-footer { display: flex; justify-content: space-between; align-items: center; padding: 14px 24px; background: var(--bg-footer); }
+.status { padding: 3px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; &.active { background: var(--positive-bg); color: var(--positive-text); } &.trial { background: rgba(230, 81, 0, 0.15); color: #ef6c00; } }
+.link { color: var(--link-color); font-size: 13px; cursor: pointer; font-weight: 500; &:hover { text-decoration: underline; } }

--- a/src/app/analytics/analytics-overview/analytics-overview.component.scss
+++ b/src/app/analytics/analytics-overview/analytics-overview.component.scss
@@ -1,22 +1,22 @@
-.page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; h1 { font-size: 28px; color: #1a237e; margin: 0; } .subtitle { color: #666; font-size: 14px; margin-top: 4px; } }
+.page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; h1 { font-size: 28px; color: var(--text-heading); margin: 0; } .subtitle { color: var(--text-secondary); font-size: 14px; margin-top: 4px; } }
 .date-range { display: flex; gap: 4px; }
-.range-btn { padding: 6px 14px; border-radius: 6px; font-size: 13px; font-weight: 600; cursor: pointer; background: #f5f5f5; color: #666; &.active { background: #1976d2; color: #fff; } }
+.range-btn { padding: 6px 14px; border-radius: 6px; font-size: 13px; font-weight: 600; cursor: pointer; background: var(--bg-filter); color: var(--text-secondary); border: none; &.active { background: var(--accent-color); color: #fff; } }
 .metrics-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 20px; }
-.metric-card { background: #fff; border-radius: 12px; padding: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+.metric-card { background: var(--bg-card); border-radius: 12px; padding: 20px; box-shadow: 0 2px 8px var(--shadow-color); transition: background-color 0.3s ease; }
 .metric-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
-.metric-label { font-size: 13px; color: #888; }
-.trend { font-size: 12px; font-weight: 600; padding: 2px 8px; border-radius: 10px; &.up { background: #e8f5e9; color: #2e7d32; } &.down { background: #e8f5e9; color: #2e7d32; } }
-.metric-value { font-size: 28px; font-weight: 700; color: #1a237e; display: block; margin-bottom: 12px; }
+.metric-label { font-size: 13px; color: var(--text-muted); }
+.trend { font-size: 12px; font-weight: 600; padding: 2px 8px; border-radius: 10px; &.up { background: var(--positive-bg); color: var(--positive-text); } &.down { background: var(--positive-bg); color: var(--positive-text); } }
+.metric-value { font-size: 28px; font-weight: 700; color: var(--text-heading); display: block; margin-bottom: 12px; }
 .mini-chart { display: flex; align-items: flex-end; gap: 4px; height: 40px; }
 .mini-bar { width: 100%; border-radius: 3px; background: #1976d2; &.green { background: #43a047; } &.orange { background: #ef6c00; } &.purple { background: #7b1fa2; } }
 .overview-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
-.card { background: #fff; border-radius: 12px; padding: 24px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); h3 { margin: 0 0 16px; color: #1a237e; } }
-.page-row { display: flex; align-items: center; gap: 12px; padding: 10px 0; border-bottom: 1px solid #f0f0f0; &:last-child { border-bottom: none; } }
-.rank { font-size: 13px; font-weight: 700; color: #1976d2; min-width: 24px; }
-.page-name { font-size: 14px; color: #333; flex: 1; }
-.views { font-size: 14px; font-weight: 600; color: #1a237e; }
+.card { background: var(--bg-card); border-radius: 12px; padding: 24px; box-shadow: 0 2px 8px var(--shadow-color); transition: background-color 0.3s ease; h3 { margin: 0 0 16px; color: var(--text-heading); } }
+.page-row { display: flex; align-items: center; gap: 12px; padding: 10px 0; border-bottom: 1px solid var(--border-light); &:last-child { border-bottom: none; } }
+.rank { font-size: 13px; font-weight: 700; color: var(--accent-color); min-width: 24px; }
+.page-name { font-size: 14px; color: var(--text-primary); flex: 1; }
+.views { font-size: 14px; font-weight: 600; color: var(--text-heading); }
 .source-list { display: flex; flex-direction: column; gap: 14px; }
 .source-row { display: flex; align-items: center; gap: 12px; }
-.source-name { min-width: 70px; font-size: 14px; color: #666; }
-.source-bar { flex: 1; height: 10px; background: #e0e0e0; border-radius: 5px; }
+.source-name { min-width: 70px; font-size: 14px; color: var(--text-secondary); }
+.source-bar { flex: 1; height: 10px; background: var(--source-bar-bg); border-radius: 5px; }
 .bar-fill { height: 100%; border-radius: 5px; &.blue { background: #1976d2; } &.green { background: #43a047; } &.purple { background: #7b1fa2; } &.orange { background: #ef6c00; } }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,9 +11,14 @@
     <a routerLink="/billing" routerLinkActive="active">Billing</a>
     <a routerLink="/analytics" routerLinkActive="active">Analytics</a>
   </div>
-  <div class="nav-user">
-    <span class="user-avatar">SA</span>
-    <span class="user-name">Saurabh Admin</span>
+  <div class="nav-right">
+    <button class="theme-toggle" (click)="toggleTheme()" [attr.aria-label]="isDark ? 'Switch to light mode' : 'Switch to dark mode'">
+      <span class="theme-icon">{{ isDark ? '&#9788;' : '&#9790;' }}</span>
+    </button>
+    <div class="nav-user">
+      <span class="user-avatar">SA</span>
+      <span class="user-name">Saurabh Admin</span>
+    </div>
   </div>
 </nav>
 <div class="main-content">

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -2,10 +2,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: linear-gradient(135deg, #1a237e, #1976d2);
+  background: var(--nav-bg);
   padding: 0 24px;
   height: 60px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 2px 8px var(--shadow-nav);
+  transition: background 0.3s ease;
 
   .nav-brand {
     display: flex;
@@ -54,6 +55,35 @@
         background: rgba(255, 255, 255, 0.2);
         color: #fff;
       }
+    }
+  }
+
+  .nav-right {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .theme-toggle {
+    background: rgba(255, 255, 255, 0.15);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 8px;
+    width: 38px;
+    height: 38px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.25);
+    }
+
+    .theme-icon {
+      font-size: 20px;
+      color: #fff;
+      line-height: 1;
     }
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { ThemeService, Theme } from './shared/services/theme.service';
+import { Observable } from 'rxjs';
 
 @Component({
   standalone: false,
@@ -8,4 +10,17 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'angular8-large-app';
+  theme$: Observable<Theme>;
+
+  constructor(private themeService: ThemeService) {
+    this.theme$ = this.themeService.theme$;
+  }
+
+  toggleTheme(): void {
+    this.themeService.toggleTheme();
+  }
+
+  get isDark(): boolean {
+    return this.themeService.currentTheme === 'dark';
+  }
 }

--- a/src/app/billing/billing-overview/billing-overview.component.scss
+++ b/src/app/billing/billing-overview/billing-overview.component.scss
@@ -1,13 +1,13 @@
-.page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; h1 { font-size: 28px; color: #1a237e; margin: 0; } .subtitle { color: #666; font-size: 14px; margin-top: 4px; } }
-.btn { padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; &.primary { background: #1976d2; color: #fff; } }
+.page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; h1 { font-size: 28px; color: var(--text-heading); margin: 0; } .subtitle { color: var(--text-secondary); font-size: 14px; margin-top: 4px; } }
+.btn { padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; &.primary { background: var(--accent-color); color: #fff; } }
 .billing-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 20px; }
-.stat-card { background: #fff; border-radius: 12px; padding: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); display: flex; align-items: center; gap: 16px; &.blue { border-left: 4px solid #1976d2; } &.green { border-left: 4px solid #43a047; } &.orange { border-left: 4px solid #ef6c00; } &.purple { border-left: 4px solid #7b1fa2; } }
+.stat-card { background: var(--bg-card); border-radius: 12px; padding: 20px; box-shadow: 0 2px 8px var(--shadow-color); display: flex; align-items: center; gap: 16px; transition: background-color 0.3s ease; &.blue { border-left: 4px solid #1976d2; } &.green { border-left: 4px solid #43a047; } &.orange { border-left: 4px solid #ef6c00; } &.purple { border-left: 4px solid #7b1fa2; } }
 .stat-icon { font-size: 32px; }
-.stat-value { display: block; font-size: 20px; font-weight: 700; color: #1a237e; }
-.stat-label { font-size: 12px; color: #888; }
+.stat-value { display: block; font-size: 20px; font-weight: 700; color: var(--text-heading); }
+.stat-label { font-size: 12px; color: var(--text-muted); }
 .billing-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
-.card { background: #fff; border-radius: 12px; padding: 24px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); h3 { margin: 0 0 16px; color: #1a237e; } }
+.card { background: var(--bg-card); border-radius: 12px; padding: 24px; box-shadow: 0 2px 8px var(--shadow-color); transition: background-color 0.3s ease; h3 { margin: 0 0 16px; color: var(--text-heading); } }
 .payment-card { display: flex; justify-content: space-between; align-items: center; }
 .card-visual { background: linear-gradient(135deg, #1a237e, #1976d2); border-radius: 12px; padding: 20px; color: #fff; min-width: 280px; .card-brand { display: block; font-size: 18px; font-weight: 700; margin-bottom: 20px; } .card-number { display: block; font-size: 16px; letter-spacing: 2px; margin-bottom: 8px; } .card-expiry { font-size: 13px; opacity: 0.8; } }
-.address { p { margin: 4px 0; font-size: 14px; color: #555; } }
-.link { color: #1976d2; font-size: 14px; cursor: pointer; font-weight: 500; &:hover { text-decoration: underline; } }
+.address { p { margin: 4px 0; font-size: 14px; color: var(--address-text); } }
+.link { color: var(--link-color); font-size: 14px; cursor: pointer; font-weight: 500; &:hover { text-decoration: underline; } }

--- a/src/app/dashboard/dashboard-home/dashboard-home.component.scss
+++ b/src/app/dashboard/dashboard-home/dashboard-home.component.scss
@@ -1,7 +1,7 @@
 .page-header {
   margin-bottom: 24px;
-  h1 { font-size: 28px; color: #1a237e; margin: 0; }
-  .subtitle { color: #666; margin-top: 4px; font-size: 14px; }
+  h1 { font-size: 28px; color: var(--text-heading); margin: 0; }
+  .subtitle { color: var(--text-secondary); margin-top: 4px; font-size: 14px; }
 }
 
 .stats-grid {
@@ -12,15 +12,16 @@
 }
 
 .stat-card {
-  background: #fff;
+  background: var(--bg-card);
   border-radius: 12px;
   padding: 20px;
   display: flex;
   align-items: center;
   gap: 16px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  box-shadow: 0 2px 8px var(--shadow-color);
   position: relative;
   overflow: hidden;
+  transition: background-color 0.3s ease;
 
   &.blue { border-left: 4px solid #1976d2; }
   &.green { border-left: 4px solid #43a047; }
@@ -31,8 +32,8 @@
   .stat-info {
     display: flex;
     flex-direction: column;
-    .stat-value { font-size: 24px; font-weight: 700; color: #1a237e; }
-    .stat-label { font-size: 13px; color: #888; }
+    .stat-value { font-size: 24px; font-weight: 700; color: var(--text-heading); }
+    .stat-label { font-size: 13px; color: var(--text-muted); }
   }
   .stat-change {
     position: absolute;
@@ -42,8 +43,8 @@
     font-weight: 600;
     padding: 2px 8px;
     border-radius: 12px;
-    &.positive { background: #e8f5e9; color: #2e7d32; }
-    &.negative { background: #fce4ec; color: #c62828; }
+    &.positive { background: var(--positive-bg); color: var(--positive-text); }
+    &.negative { background: var(--negative-bg); color: var(--negative-text); }
   }
 }
 
@@ -54,11 +55,12 @@
 }
 
 .card {
-  background: #fff;
+  background: var(--bg-card);
   border-radius: 12px;
   padding: 24px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
-  h3 { margin: 0 0 20px; color: #1a237e; font-size: 16px; }
+  box-shadow: 0 2px 8px var(--shadow-color);
+  transition: background-color 0.3s ease;
+  h3 { margin: 0 0 20px; color: var(--text-heading); font-size: 16px; }
 }
 
 .bar-chart {
@@ -69,7 +71,7 @@
   padding-top: 20px;
   .bar {
     width: 40px;
-    background: linear-gradient(180deg, #1976d2, #64b5f6);
+    background: var(--bar-gradient);
     border-radius: 6px 6px 0 0;
     position: relative;
     transition: height 0.3s;
@@ -80,7 +82,7 @@
       left: 50%;
       transform: translateX(-50%);
       font-size: 12px;
-      color: #888;
+      color: var(--text-muted);
     }
   }
 }
@@ -96,7 +98,7 @@
   align-items: center;
   gap: 12px;
   padding-bottom: 16px;
-  border-bottom: 1px solid #f0f0f0;
+  border-bottom: 1px solid var(--border-light);
   &:last-child { border-bottom: none; padding-bottom: 0; }
 }
 
@@ -114,6 +116,6 @@
 .activity-content {
   display: flex;
   flex-direction: column;
-  strong { font-size: 14px; color: #333; }
-  .activity-time { font-size: 12px; color: #999; }
+  strong { font-size: 14px; color: var(--text-primary); }
+  .activity-time { font-size: 12px; color: var(--text-subtle); }
 }

--- a/src/app/reports/report-list/report-list.component.scss
+++ b/src/app/reports/report-list/report-list.component.scss
@@ -1,11 +1,11 @@
-.page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; h1 { font-size: 28px; color: #1a237e; margin: 0; } .subtitle { color: #666; font-size: 14px; margin-top: 4px; } }
-.btn { padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; &.primary { background: #1976d2; color: #fff; &:hover { background: #1565c0; } } }
+.page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; h1 { font-size: 28px; color: var(--text-heading); margin: 0; } .subtitle { color: var(--text-secondary); font-size: 14px; margin-top: 4px; } }
+.btn { padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; &.primary { background: var(--accent-color); color: #fff; &:hover { opacity: 0.9; } } }
 .toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
-.search-input { padding: 10px 16px; border: 1px solid #e0e0e0; border-radius: 8px; font-size: 14px; width: 300px; &:focus { outline: none; border-color: #1976d2; } }
-.filters { display: flex; gap: 8px; } .filter-btn { padding: 8px 16px; border-radius: 20px; font-size: 13px; cursor: pointer; background: #f5f5f5; color: #666; &.active { background: #1976d2; color: #fff; } }
-.table-card { background: #fff; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); overflow: hidden; }
-table { width: 100%; border-collapse: collapse; th { text-align: left; padding: 14px 16px; background: #fafafa; color: #888; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; } td { padding: 14px 16px; font-size: 14px; border-bottom: 1px solid #f0f0f0; } tr:hover td { background: #f8f9ff; } }
+.search-input { padding: 10px 16px; border: 1px solid var(--border-color); border-radius: 8px; font-size: 14px; width: 300px; background: var(--bg-input); color: var(--text-primary); &:focus { outline: none; border-color: var(--accent-color); } }
+.filters { display: flex; gap: 8px; } .filter-btn { padding: 8px 16px; border-radius: 20px; font-size: 13px; cursor: pointer; background: var(--bg-filter); color: var(--text-secondary); border: none; &.active { background: var(--accent-color); color: #fff; } }
+.table-card { background: var(--bg-card); border-radius: 12px; box-shadow: 0 2px 8px var(--shadow-color); overflow: hidden; transition: background-color 0.3s ease; }
+table { width: 100%; border-collapse: collapse; th { text-align: left; padding: 14px 16px; background: var(--bg-table-header); color: var(--text-muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; } td { padding: 14px 16px; font-size: 14px; border-bottom: 1px solid var(--border-light); color: var(--text-primary); } tr:hover td { background: var(--bg-card-hover); } }
 .name-cell { font-weight: 500; display: flex; align-items: center; gap: 10px; }
 .icon { font-size: 20px; &.blue { color: #1976d2; } &.green { color: #43a047; } &.purple { color: #7b1fa2; } &.orange { color: #ef6c00; } }
-.status { padding: 3px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; &.published { background: #e8f5e9; color: #2e7d32; } &.draft { background: #fff3e0; color: #e65100; } }
-.action-link { color: #1976d2; cursor: pointer; font-size: 13px; &:hover { text-decoration: underline; } }
+.status { padding: 3px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; &.published { background: var(--positive-bg); color: var(--positive-text); } &.draft { background: rgba(230, 81, 0, 0.15); color: #ef6c00; } }
+.action-link { color: var(--link-color); cursor: pointer; font-size: 13px; &:hover { text-decoration: underline; } }

--- a/src/app/shared/services/theme.service.ts
+++ b/src/app/shared/services/theme.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export type Theme = 'light' | 'dark';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ThemeService {
+  private readonly STORAGE_KEY = 'app-theme';
+  private themeSubject: BehaviorSubject<Theme>;
+
+  theme$ = this.getInitialTheme();
+
+  constructor() {
+    const saved = this.getSavedTheme();
+    this.themeSubject = new BehaviorSubject<Theme>(saved);
+    this.theme$ = this.themeSubject.asObservable();
+    this.applyTheme(saved);
+  }
+
+  get currentTheme(): Theme {
+    return this.themeSubject.value;
+  }
+
+  toggleTheme(): void {
+    const next: Theme = this.currentTheme === 'light' ? 'dark' : 'light';
+    this.themeSubject.next(next);
+    this.applyTheme(next);
+    localStorage.setItem(this.STORAGE_KEY, next);
+  }
+
+  private getSavedTheme(): Theme {
+    try {
+      const saved = localStorage.getItem(this.STORAGE_KEY);
+      if (saved === 'dark' || saved === 'light') {
+        return saved;
+      }
+    } catch {}
+    return 'light';
+  }
+
+  private getInitialTheme() {
+    return new BehaviorSubject<Theme>(this.getSavedTheme()).asObservable();
+  }
+
+  private applyTheme(theme: Theme): void {
+    document.body.classList.remove('theme-light', 'theme-dark');
+    document.body.classList.add(`theme-${theme}`);
+  }
+}

--- a/src/app/users/user-list/user-list.component.scss
+++ b/src/app/users/user-list/user-list.component.scss
@@ -1,19 +1,19 @@
-.page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; h1 { font-size: 28px; color: #1a237e; margin: 0; } .subtitle { color: #666; font-size: 14px; margin-top: 4px; } }
-.btn { padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; &.primary { background: #1976d2; color: #fff; &:hover { background: #1565c0; } } }
+.page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; h1 { font-size: 28px; color: var(--text-heading); margin: 0; } .subtitle { color: var(--text-secondary); font-size: 14px; margin-top: 4px; } }
+.btn { padding: 10px 20px; border: none; border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer; &.primary { background: var(--accent-color); color: #fff; &:hover { opacity: 0.9; } } }
 .toolbar { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
-.search-input { padding: 10px 16px; border: 1px solid #e0e0e0; border-radius: 8px; font-size: 14px; width: 300px; &:focus { outline: none; border-color: #1976d2; } }
+.search-input { padding: 10px 16px; border: 1px solid var(--border-color); border-radius: 8px; font-size: 14px; width: 300px; background: var(--bg-input); color: var(--text-primary); &:focus { outline: none; border-color: var(--accent-color); } }
 .filters { display: flex; gap: 8px; }
-.filter-btn { padding: 8px 16px; border-radius: 20px; font-size: 13px; cursor: pointer; background: #f5f5f5; color: #666; &.active { background: #1976d2; color: #fff; } }
-.table-card { background: #fff; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); overflow: hidden; }
+.filter-btn { padding: 8px 16px; border-radius: 20px; font-size: 13px; cursor: pointer; background: var(--bg-filter); color: var(--text-secondary); border: none; &.active { background: var(--accent-color); color: #fff; } }
+.table-card { background: var(--bg-card); border-radius: 12px; box-shadow: 0 2px 8px var(--shadow-color); overflow: hidden; transition: background-color 0.3s ease; }
 table { width: 100%; border-collapse: collapse;
-  th { text-align: left; padding: 14px 16px; background: #fafafa; color: #888; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; border-bottom: 2px solid #e0e0e0; }
-  td { padding: 14px 16px; font-size: 14px; border-bottom: 1px solid #f0f0f0; }
-  tr:hover td { background: #f8f9ff; }
+  th { text-align: left; padding: 14px 16px; background: var(--bg-table-header); color: var(--text-muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; border-bottom: 2px solid var(--border-color); }
+  td { padding: 14px 16px; font-size: 14px; border-bottom: 1px solid var(--border-light); color: var(--text-primary); }
+  tr:hover td { background: var(--bg-card-hover); }
 }
 .user-cell { display: flex; align-items: center; gap: 10px; font-weight: 500; }
 .avatar { width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 700; color: #fff; &.blue { background: #1976d2; } &.green { background: #43a047; } &.purple { background: #7b1fa2; } &.orange { background: #ef6c00; } }
-.role-badge { padding: 3px 10px; border-radius: 12px; font-size: 12px; font-weight: 600; &.admin { background: #fce4ec; color: #c62828; } &.editor { background: #e3f2fd; color: #1565c0; } &.viewer { background: #f3e5f5; color: #6a1b9a; } }
+.role-badge { padding: 3px 10px; border-radius: 12px; font-size: 12px; font-weight: 600; &.admin { background: var(--negative-bg); color: var(--negative-text); } &.editor { background: rgba(25, 118, 210, 0.15); color: var(--accent-color); } &.viewer { background: rgba(123, 31, 162, 0.15); color: #ab47bc; } }
 .status-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 6px; &.active { background: #43a047; } &.inactive { background: #bdbdbd; } }
-.action-link { color: #1976d2; cursor: pointer; font-size: 13px; &:hover { text-decoration: underline; } }
+.action-link { color: var(--link-color); cursor: pointer; font-size: 13px; &:hover { text-decoration: underline; } }
 .pagination { display: flex; justify-content: center; padding: 16px; gap: 4px; }
-.page-btn { width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; border-radius: 6px; font-size: 13px; cursor: pointer; color: #666; &.active { background: #1976d2; color: #fff; } &:hover:not(.active) { background: #f0f0f0; } }
+.page-btn { width: 32px; height: 32px; display: flex; align-items: center; justify-content: center; border-radius: 6px; font-size: 13px; cursor: pointer; color: var(--text-secondary); background: transparent; border: none; &.active { background: var(--accent-color); color: #fff; } &:hover:not(.active) { background: var(--bg-filter); } }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,10 +1,63 @@
 /* Global styles for Angular 8 Large App */
 
-$primary-color: #1976d2;
-$secondary-color: #ff4081;
-$background-color: #fafafa;
-$text-color: #333;
-$border-color: #e0e0e0;
+:root,
+body.theme-light {
+  --bg-primary: #fafafa;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f8f9ff;
+  --bg-table-header: #fafafa;
+  --bg-input: #ffffff;
+  --bg-filter: #f5f5f5;
+  --bg-footer: #fafafa;
+  --text-primary: #333333;
+  --text-heading: #1a237e;
+  --text-secondary: #666666;
+  --text-muted: #888888;
+  --text-subtle: #999999;
+  --border-color: #e0e0e0;
+  --border-light: #f0f0f0;
+  --shadow-color: rgba(0, 0, 0, 0.08);
+  --shadow-nav: rgba(0, 0, 0, 0.15);
+  --nav-bg: linear-gradient(135deg, #1a237e, #1976d2);
+  --link-color: #1976d2;
+  --accent-color: #1976d2;
+  --positive-bg: #e8f5e9;
+  --positive-text: #2e7d32;
+  --negative-bg: #fce4ec;
+  --negative-text: #c62828;
+  --bar-gradient: linear-gradient(180deg, #1976d2, #64b5f6);
+  --source-bar-bg: #e0e0e0;
+  --address-text: #555555;
+}
+
+body.theme-dark {
+  --bg-primary: #121212;
+  --bg-card: #1e1e1e;
+  --bg-card-hover: #2a2a3a;
+  --bg-table-header: #252525;
+  --bg-input: #2a2a2a;
+  --bg-filter: #2a2a2a;
+  --bg-footer: #252525;
+  --text-primary: #e0e0e0;
+  --text-heading: #90caf9;
+  --text-secondary: #aaaaaa;
+  --text-muted: #999999;
+  --text-subtle: #777777;
+  --border-color: #333333;
+  --border-light: #2a2a2a;
+  --shadow-color: rgba(0, 0, 0, 0.3);
+  --shadow-nav: rgba(0, 0, 0, 0.4);
+  --nav-bg: linear-gradient(135deg, #0d1440, #0d47a1);
+  --link-color: #64b5f6;
+  --accent-color: #64b5f6;
+  --positive-bg: #1b3a1b;
+  --positive-text: #66bb6a;
+  --negative-bg: #3a1b1b;
+  --negative-text: #ef9a9a;
+  --bar-gradient: linear-gradient(180deg, #64b5f6, #1976d2);
+  --source-bar-bg: #333333;
+  --address-text: #bbbbbb;
+}
 
 * {
   margin: 0;
@@ -14,17 +67,18 @@ $border-color: #e0e0e0;
 
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-  background-color: $background-color;
-  color: $text-color;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
   line-height: 1.6;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 a {
-  color: $primary-color;
+  color: var(--link-color);
   text-decoration: none;
 
   &:hover {
-    color: darken($primary-color, 10%);
+    opacity: 0.85;
   }
 }
 
@@ -32,19 +86,4 @@ a {
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 16px;
-}
-
-nav {
-  background-color: $primary-color;
-  padding: 12px 24px;
-
-  a {
-    color: white;
-    margin-right: 16px;
-    font-weight: 500;
-
-    &:hover {
-      opacity: 0.85;
-    }
-  }
 }


### PR DESCRIPTION
## Dark / Light Theme Toggle

Fixes https://github.com/saurabhksinha900/AngularDevin/issues/3

### Changes
- **ThemeService** (`src/app/shared/services/theme.service.ts`) - manages theme state with localStorage persistence
- **Theme toggle button** in nav bar with moon/sun icons
- **CSS custom properties** defined in `styles.scss` for both light and dark palettes
- **All 6 module styles** updated to use CSS variables for backgrounds, text, borders, shadows, etc.
- Smooth 0.3s transitions between themes

### Screenshots

#### Light Theme
![Light Dashboard](/home/ubuntu/screenshots/localhost_4200_203232.png)

#### Dark Theme
![Dark Dashboard](/home/ubuntu/screenshots/localhost_4200_203253.png)
![Dark Users](/home/ubuntu/screenshots/localhost_4200_users_203303.png)
![Dark Accounts](/home/ubuntu/screenshots/localhost_4200_203311.png)
![Dark Analytics](/home/ubuntu/screenshots/localhost_4200_203320.png)

---
**Link to Devin run**: https://app.devin.ai/sessions/2df18b78ec514dd2ae10e1e2bc730706
**Requested by**: @saurabh-sinha_infosys (saurabh.sinha@infosys.com)